### PR TITLE
修复当使用TabBox的RemoteAt方法删除子控件时，选中索引没有重新计算的问题

### DIFF
--- a/tool_kits/duilib/Box/TabBox.cpp
+++ b/tool_kits/duilib/Box/TabBox.cpp
@@ -90,6 +90,13 @@ bool TabBox::Remove(Control* pControl)
 	return ret;
 }
 
+bool TabBox::RemoveAt(std::size_t iIndex)
+{
+	Control* pControl = GetItemAt(iIndex);
+	if (pControl == NULL) return false;
+	return Remove(pControl);
+}
+
 void TabBox::RemoveAll()
 {
 	m_iCurSel = -1;

--- a/tool_kits/duilib/Box/TabBox.cpp
+++ b/tool_kits/duilib/Box/TabBox.cpp
@@ -16,8 +16,10 @@ bool TabBox::Add(Control* pControl)
 
 	if(m_iCurSel == -1 && pControl->IsVisible()) {
 		m_iCurSel = GetItemIndex(pControl);
-	}
-	else {
+	} 
+
+	if (m_iCurSel != GetItemIndex(pControl) || !pControl->IsVisible())
+	{
 		if (!IsFadeSwitch()) {
 			pControl->SetVisible(false);
 		}
@@ -27,7 +29,6 @@ bool TabBox::Add(Control* pControl)
 		}
 		pControl->SetAlpha(0);
 	}
-
 	return ret;
 }
 
@@ -221,7 +222,7 @@ bool TabBox::SelectItem(const std::wstring& pControlName)
 
 void TabBox::SetAttribute(const std::wstring& strName, const std::wstring& strValue)
 {
-	if( strName == _T("selectedid") ) SelectItem(_ttoi(strValue.c_str()));
+	if (strName == _T("selectedid")) m_iCurSel = _ttoi(strValue.c_str());
 	else if( strName == _T("fadeswitch") ) SetFadeSwitch(strValue == _T("true"));
 	else Box::SetAttribute(strName, strValue);
 }

--- a/tool_kits/duilib/Box/TabBox.h
+++ b/tool_kits/duilib/Box/TabBox.h
@@ -15,6 +15,7 @@ public:
 	virtual bool Add(Control* pControl) override;
 	virtual bool AddAt(Control* pControl, std::size_t iIndex) override;
 	virtual bool Remove(Control* pControl) override;
+	virtual bool RemoveAt(std::size_t iIndex) override;
 	virtual void RemoveAll() override;
 	virtual void SetAttribute(const std::wstring& strName, const std::wstring& strValue) override;
 


### PR DESCRIPTION
重载RemoteAt，在删除子控件时，重新计算选中索引