### PR TITLE
修复Combo控件在XML中设置dropbox属性无效的bug

### DIFF
--- a/tool_kits/duilib/Control/Combo.cpp
+++ b/tool_kits/duilib/Control/Combo.cpp
@@ -257,6 +257,7 @@ std::wstring Combo::GetDropBoxAttributeList()
 void Combo::SetDropBoxAttributeList(const std::wstring& pstrList)
 {
     m_sDropBoxAttributes = pstrList;
+    m_pLayout->ApplyAttributeList(pstrList);
 }
 
 CSize Combo::GetDropBoxSize() const

--- a/tool_kits/duilib/Core/Box.cpp
+++ b/tool_kits/duilib/Core/Box.cpp
@@ -1015,7 +1015,8 @@ void ScrollableBox::PaintChild(IRenderContext* pRender, const UiRect& rcPaint)
 		}
 		else {
 			CSize scrollPos = GetScrollPos();
-			UiRect rcNewPaint = rcPaint;
+			UiRect rcNewPaint = GetPaddingPos();
+			AutoClip alphaClip(pRender, rcNewPaint, m_bClip);
 			rcNewPaint.Offset(scrollPos.cx, scrollPos.cy);
 			rcNewPaint.Offset(GetRenderOffset().x, GetRenderOffset().y);
 


### PR DESCRIPTION
在xml设置dropbox属性
```xml
dropbox="bkimage=&quot;file='tag/combo_bg.png' corner='10,18,6,8'&quot; padding=&quot;10,18,6,8&quot; scrollbarpadding=&quot;10,18,6,8&quot;"
```