### PR TITLE
【字体增加删除线的属性】

### DIFF
--- a/tool_kits/duilib/Control/RichEdit.cpp
+++ b/tool_kits/duilib/Control/RichEdit.cpp
@@ -1287,7 +1287,7 @@ void RichEdit::SetFont(const std::wstring& strFontId)
     }
 }
 
-void RichEdit::SetFont(const std::wstring& pStrFontName, int nSize, bool bBold, bool bUnderline, bool bItalic)
+void RichEdit::SetFont(const std::wstring& pStrFontName, int nSize, bool bBold, bool bUnderline, bool bStrikeOut, bool bItalic)
 {
     if( m_pTwh ) {
         LOGFONT lf = { 0 };
@@ -1297,6 +1297,7 @@ void RichEdit::SetFont(const std::wstring& pStrFontName, int nSize, bool bBold, 
         lf.lfHeight = -nSize;
         if( bBold ) lf.lfWeight += FW_BOLD;
         if( bUnderline ) lf.lfUnderline = TRUE;
+		if (bStrikeOut) lf.lfStrikeOut = TRUE;
         if( bItalic ) lf.lfItalic = TRUE;
         HFONT hFont = ::CreateFontIndirect(&lf);
         if( hFont == NULL ) return;

--- a/tool_kits/duilib/Control/RichEdit.h
+++ b/tool_kits/duilib/Control/RichEdit.h
@@ -133,10 +133,11 @@ public:
 	 * @param[in] nSize 字体大小
 	 * @param[in] bBold 是否粗体显示
 	 * @param[in] bUnderline 是否带有下划线
+	 * @param[in] bStrikeOut 是否带有删除线
 	 * @param[in] bItalic 是否斜体显示
 	 * @return 无
 	 */
-    void SetFont(const std::wstring& pStrFontName, int nSize, bool bBold, bool bUnderline, bool bItalic);
+	void SetFont(const std::wstring& pStrFontName, int nSize, bool bBold, bool bUnderline, bool bStrikeOut, bool bItalic);
 
 	/**
 	 * @brief 获取窗口样式

--- a/tool_kits/duilib/Core/GlobalManager.cpp
+++ b/tool_kits/duilib/Core/GlobalManager.cpp
@@ -295,7 +295,7 @@ void GlobalManager::RemoveAllImages()
 	m_mImageHash.clear();
 }
 
-HFONT GlobalManager::AddFont(const std::wstring& strFontId, const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bItalic, bool bDefault)
+HFONT GlobalManager::AddFont(const std::wstring& strFontId, const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bStrikeOut, bool bItalic, bool bDefault)
 {
 	std::wstring strNewFontId = strFontId;
 	if (strNewFontId.empty())
@@ -319,6 +319,7 @@ HFONT GlobalManager::AddFont(const std::wstring& strFontId, const std::wstring& 
 	lf.lfHeight = -DpiManager::GetInstance()->ScaleInt(nSize);
 	if (bBold) lf.lfWeight += FW_BOLD;
 	if (bUnderline) lf.lfUnderline = TRUE;
+	if (bStrikeOut) lf.lfStrikeOut = TRUE;
 	if (bItalic) lf.lfItalic = TRUE;
 	HFONT hFont = ::CreateFontIndirect(&lf);
 	if (hFont == NULL) return NULL;
@@ -330,6 +331,7 @@ HFONT GlobalManager::AddFont(const std::wstring& strFontId, const std::wstring& 
 	pFontInfo->iSize = nSize;
 	pFontInfo->bBold = bBold;
 	pFontInfo->bUnderline = bUnderline;
+	pFontInfo->bStrikeOut = bStrikeOut;
 	pFontInfo->bItalic = bItalic;
 	::ZeroMemory(&pFontInfo->tm, sizeof(pFontInfo->tm));
 
@@ -364,12 +366,13 @@ HFONT GlobalManager::GetFont(const std::wstring& strFontId)
 	return nullptr;
 }
 
-HFONT GlobalManager::GetFont(const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bItalic)
+HFONT GlobalManager::GetFont(const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bStrikeOut, bool bItalic)
 {
 	for (auto it = m_mCustomFonts.begin(); it != m_mCustomFonts.end(); it++) {
 		auto pFontInfo = it->second;
 		if (pFontInfo->sFontName == strFontName && pFontInfo->iSize == nSize &&
-			pFontInfo->bBold == bBold && pFontInfo->bUnderline == bUnderline && pFontInfo->bItalic == bItalic)
+			pFontInfo->bBold == bBold && pFontInfo->bUnderline == bUnderline && 
+			pFontInfo->bStrikeOut == bStrikeOut && pFontInfo->bItalic == bItalic)
 			return pFontInfo->hFont;
 	}
 	return NULL;
@@ -414,12 +417,13 @@ bool GlobalManager::FindFont(HFONT hFont)
 	return false;
 }
 
-bool GlobalManager::FindFont(const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bItalic)
+bool GlobalManager::FindFont(const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bStrikeOut, bool bItalic)
 {
 	for (auto it = m_mCustomFonts.begin(); it != m_mCustomFonts.end(); it++) {
 		auto pFontInfo = it->second;
 		if (pFontInfo->sFontName == strFontName && pFontInfo->iSize == nSize &&
-			pFontInfo->bBold == bBold && pFontInfo->bUnderline == bUnderline && pFontInfo->bItalic == bItalic)
+			pFontInfo->bBold == bBold && pFontInfo->bUnderline == bUnderline && 
+			pFontInfo->bStrikeOut == bStrikeOut && pFontInfo->bItalic == bItalic)
 			return true;
 	}
 	return false;

--- a/tool_kits/duilib/Core/GlobalManager.h
+++ b/tool_kits/duilib/Core/GlobalManager.h
@@ -200,11 +200,12 @@ public:
 	 * @param[in] nSize 字体大小
 	 * @param[in] bBold 是否粗体
 	 * @param[in] bUnderline 是否有下划线
+	 * @param[in] bStrikeOut 是否带有删除线
 	 * @param[in] bItalic 是否倾斜
 	 * @param[in] bDefault 是否默认
 	 * @return 返回字体的 HFONT 句柄
 	 */
-	static HFONT AddFont(const std::wstring& strFontId, const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bItalic, bool bDefault);
+	static HFONT AddFont(const std::wstring& strFontId, const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bStrikeOut, bool bItalic, bool bDefault);
 
 	/**
 	 * @brief 根据索引返回一个字体信息
@@ -225,10 +226,11 @@ public:
 	 * @param[in] nSize 字体大小
 	 * @param[in] bBold 是否粗体
 	 * @param[in] bUnderline 是否有下划线
+	 * @param[in] bStrikeOut 是否带有删除线
 	 * @param[in] bItalic 是否倾斜
 	 * @return 返回字体的 HFONT 句柄
 	 */
-	static HFONT GetFont(const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bItalic);
+	static HFONT GetFont(const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bStrikeOut, bool bItalic);
 
 	/**
 	 * @brief 获取字体信息
@@ -261,12 +263,13 @@ public:
 	 * @param[in] nSize 字体大小
 	 * @param[in] bBold 是否粗体
 	 * @param[in] bUnderline 是否有下划线
+	 * @param[in] bStrikeOut 是否带有删除线
 	 * @param[in] bItalic 是否倾斜
 	 * @return 返回是否存在
 	 *     @retval true 存在
 	 *     @retval false 不存在
 	 */
-	static bool FindFont(const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bItalic);
+	static bool FindFont(const std::wstring& strFontName, int nSize, bool bBold, bool bUnderline, bool bStrikeOut, bool bItalic);
 
 	/**
 	 * @brief 根据字体索引删除字体

--- a/tool_kits/duilib/Core/Window.cpp
+++ b/tool_kits/duilib/Core/Window.cpp
@@ -82,6 +82,7 @@ Window::Window() :
 	m_defaultFontInfo.iSize = -lf.lfHeight;
 	m_defaultFontInfo.bBold = (lf.lfWeight >= FW_BOLD);
 	m_defaultFontInfo.bUnderline = (lf.lfUnderline == TRUE);
+	m_defaultFontInfo.bStrikeOut = (lf.lfStrikeOut == TRUE);
 	m_defaultFontInfo.bItalic = (lf.lfItalic == TRUE);
 	::ZeroMemory(&m_defaultFontInfo.tm, sizeof(m_defaultFontInfo.tm));
 }

--- a/tool_kits/duilib/Core/Window.h
+++ b/tool_kits/duilib/Core/Window.h
@@ -31,6 +31,7 @@ typedef struct tagTFontInfo
 	int iSize;
 	bool bBold;
 	bool bUnderline;
+	bool bStrikeOut;
 	bool bItalic;
 	TEXTMETRIC tm;
 } TFontInfo;

--- a/tool_kits/duilib/Core/WindowBuilder.cpp
+++ b/tool_kits/duilib/Core/WindowBuilder.cpp
@@ -198,6 +198,7 @@ Box* WindowBuilder::Create(CreateControlCallback pCallback, Window* pManager, Bo
 					int size = 12;
 					bool bold = false;
 					bool underline = false;
+					bool strikeout = false;
 					bool italic = false;
 					bool isDefault = false;
 					for( int i = 0; i < nAttributes; i++ ) {
@@ -219,6 +220,9 @@ Box* WindowBuilder::Create(CreateControlCallback pCallback, Window* pManager, Bo
 						else if( strName == _T("underline") ) {
 							underline = (strValue == _T("true"));
 						}
+						else if (strName == _T("strikeout")) {
+							strikeout = (strValue == _T("true"));
+						}
 						else if( strName == _T("italic") ) {
 							italic = (strValue == _T("true"));
 						}
@@ -227,7 +231,7 @@ Box* WindowBuilder::Create(CreateControlCallback pCallback, Window* pManager, Bo
 						}
 					}
 					if( !strFontName.empty() ) {
-						GlobalManager::AddFont(strFontId, strFontName, size, bold, underline, italic, isDefault);
+						GlobalManager::AddFont(strFontId, strFontName, size, bold, underline,strikeout, italic, isDefault);
 					}
 				}
 				else if( strClass == _T("Class") ) {


### PR DESCRIPTION
<!-- 这里写下您的 PR 修复了什么问题或新增了什么功能 -->
Fixed # 增加字体的删除线属性

<!-- 请确保您的拉取求情提交至开发分（development）支而不是主分支（master） -->
<!-- 请仔细查看您的提交确保同文件下使用的是与原项目相同的缩进方式和代码风格 -->
<!-- 写下您的 PR 工作的具体内容，比如解决问题的思路和新功能的作用 -->
     
![image](https://user-images.githubusercontent.com/53515032/65480283-7ab23880-dec3-11e9-849a-ee4d857c1c10.png)
视觉希望某些已完成的状态的字体是带删除线的，发现我们的Duilib没有提供，这个改动也比较简单，GDI的LOGFONT里面的lfStrikeOut属性就支持了。
