### PR TITLE
多级菜单的实现，支持xml中静态添加或者代码中动态添加

### DIFF
--- a/bin/resources/themes/default/menu/settings_menu.xml
+++ b/bin/resources/themes/default/menu/settings_menu.xml
@@ -4,14 +4,38 @@
     <MenuElement class="menu_element" name="first" width="180">
       <Button width="auto" height="auto" bkimage="menu_settings.png" valign="center" mouse="false"/>
       <Label class="menu_text" text="System settings" margin="30,0,0,0"/>
+	   <MenuElement class="menu_element" name="first_2" width="180">
+	      <Button width="auto" height="auto" bkimage="menu_settings.png" valign="center" mouse="false"/>
+		  <Label class="menu_text" text="System settings" margin="30,0,0,0"/>
+		   <MenuElement class="menu_element" name="first_3" width="180">
+	      <Button width="auto" height="auto" bkimage="menu_settings.png" valign="center" mouse="false"/>
+		  <Label class="menu_text" text="System settings" margin="30,0,0,0"/>
+	   </MenuElement>
+	   </MenuElement>
+	    <MenuElement class="menu_element" name="first_4" width="180">
+	      <Button width="auto" height="auto" bkimage="menu_settings.png" valign="center" mouse="false"/>
+		  <Label class="menu_text" text="System settings" margin="30,0,0,0"/>
+	   </MenuElement>
     </MenuElement>
     <MenuElement class="menu_element" name="second" width="180">
       <Button width="auto" height="auto" bkimage="menu_proxy.png" valign="center" mouse="false"/>
       <Label class="menu_text" text="Proxy settings" margin="30,0,0,0"/>
+	   <MenuElement class="menu_element" name="first_5" width="180">
+	      <Button width="auto" height="auto" bkimage="menu_settings.png" valign="center" mouse="false"/>
+		  <Label class="menu_text" text="System settings" margin="30,0,0,0"/>
+	   </MenuElement>
+	    <MenuElement class="menu_element" name="first_6" width="180">
+	      <Button width="auto" height="auto" bkimage="menu_settings.png" valign="center" mouse="false"/>
+		  <Label class="menu_text" text="System settings" margin="30,0,0,0"/>
+	   </MenuElement>
     </MenuElement>
     <MenuElement class="menu_element" name="third" width="180">
       <Button width="auto" height="auto" bkimage="menu_logs.png" valign="center" mouse="false"/>
       <Label class="menu_text" text="Logs directory" margin="30,0,0,0"/>
+	   <MenuElement class="menu_element" name="first_7" width="180">
+	      <Button width="auto" height="auto" bkimage="menu_settings.png" valign="center" mouse="false"/>
+		  <Label class="menu_text" text="System settings" margin="30,0,0,0"/>
+	   </MenuElement>
     </MenuElement>
   </VListBox>
 </Window>

--- a/bin/resources/themes/default/menu/submenu.xml
+++ b/bin/resources/themes/default/menu/submenu.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window>
+  <VListBox class="menu" name="submenu">
+   
+  </VListBox>
+</Window>

--- a/examples/controls/controls_form.cpp
+++ b/examples/controls/controls_form.cpp
@@ -127,6 +127,25 @@ void ControlForm::InitWindow()
 		nim_comp::CMenuWnd* pMenu = new nim_comp::CMenuWnd(NULL);
 		ui::STRINGorID xml(L"settings_menu.xml");
 		pMenu->Init(xml, _T("xml"), point);
+
+		//这里增加动态添加菜单的例子
+		{
+			nim_comp::CMenuElementUI* pThird = static_cast<nim_comp::CMenuElementUI*>(pMenu->FindControl(L"third"));
+
+			nim_comp::CMenuElementUI* pItem = new nim_comp::CMenuElementUI;
+			pItem->SetText(L"动态添加菜单1");
+			pItem->SetClass(L"menu_element");
+			pItem->SetFixedWidth(200);
+			pThird->Add(pItem);
+
+			nim_comp::CMenuElementUI* pItem2 = new nim_comp::CMenuElementUI;
+			pItem2->SetText(L"动态添加菜单2");
+			pItem2->SetClass(L"menu_element");
+			pItem2->SetFixedWidth(200);
+			pItem->Add(pItem2);
+
+		}
+
 		return true;
 	});
 }

--- a/ui_components/menu/observer_impl_base.hpp
+++ b/ui_components/menu/observer_impl_base.hpp
@@ -1,0 +1,176 @@
+#ifndef OBSERVER_IMPL_BASE_HPP
+#define OBSERVER_IMPL_BASE_HPP
+
+#include <map>
+
+template <typename ReturnT, typename ParamT>
+class ReceiverImplBase;
+
+template <typename ReturnT, typename ParamT>
+class ObserverImplBase
+{
+public:
+	virtual void AddReceiver(ReceiverImplBase<ReturnT, ParamT>* receiver) = 0;
+	virtual void RemoveReceiver(ReceiverImplBase<ReturnT, ParamT>* receiver) = 0;
+	virtual ReturnT Broadcast(ParamT param) = 0;
+	virtual ReturnT RBroadcast(ParamT param) = 0;
+	virtual ReturnT Notify(ParamT param) = 0;
+};
+
+template <typename ReturnT, typename ParamT>
+class ReceiverImplBase
+{
+public:
+	virtual void AddObserver(ObserverImplBase<ReturnT, ParamT>* observer) = 0;
+	virtual void RemoveObserver() = 0;
+	virtual ReturnT Receive(ParamT param) = 0;
+	virtual ReturnT Respond(ParamT param, ObserverImplBase<ReturnT, ParamT>* observer) = 0;
+};
+
+template <typename ReturnT, typename ParamT>
+class ReceiverImpl;
+
+template <typename ReturnT, typename ParamT>
+class ObserverImpl : public ObserverImplBase<ReturnT, ParamT>
+{
+	template <typename ReturnT, typename ParamT>
+	friend class Iterator;
+public:
+	ObserverImpl()
+	{}
+
+	virtual ~ObserverImpl()	{}
+
+	virtual void AddReceiver(ReceiverImplBase<ReturnT, ParamT>* receiver)
+	{
+		if (receiver == NULL)
+			return;
+
+		receivers_.push_back(receiver);
+		receiver->AddObserver(this);
+	}
+
+	virtual void RemoveReceiver(ReceiverImplBase<ReturnT, ParamT>* receiver)
+	{
+		if (receiver == NULL)
+			return;
+
+		ReceiversVector::iterator it = receivers_.begin();
+		for (; it != receivers_.end(); ++it)
+		{
+			if (*it == receiver)
+			{
+				receivers_.erase(it);
+				break;
+			}
+		}
+	}
+
+	virtual ReturnT Broadcast(ParamT param)
+	{
+		ReceiversVector::iterator it = receivers_.begin();
+		for (; it != receivers_.end(); ++it)
+		{
+			(*it)->Receive(param);
+		}
+
+		return ReturnT();
+	}
+
+	virtual ReturnT RBroadcast(ParamT param)
+	{
+		ReceiversVector::reverse_iterator it = receivers_.rbegin();
+		for (; it != receivers_.rend(); ++it)
+		{
+			(*it)->Receive(param);
+		}
+
+		return ReturnT();
+	}
+
+	virtual ReturnT Notify(ParamT param)
+	{
+		ReceiversVector::iterator it = receivers_.begin();
+		for (; it != receivers_.end(); ++it)
+		{
+			(*it)->Respond(param, this);
+		}
+
+		return ReturnT();
+	}
+
+	template <typename ReturnT, typename ParamT>
+	class Iterator
+	{
+		ObserverImpl<ReturnT, ParamT> & _tbl;
+		DWORD index;
+		ReceiverImplBase<ReturnT, ParamT>* ptr;
+	public:
+		Iterator( ObserverImpl & table )
+			: _tbl( table ), index(0), ptr(NULL)
+		{}
+
+		Iterator( const Iterator & v )
+			: _tbl( v._tbl ), index(v.index), ptr(v.ptr)
+		{}
+
+		ReceiverImplBase<ReturnT, ParamT>* next()
+		{
+			if ( index >= _tbl.receivers_.size() )
+				return NULL;
+
+			for ( ; index < _tbl.receivers_.size(); )
+			{
+				ptr = _tbl.receivers_[ index++ ];
+				if ( ptr )
+					return ptr;
+			}
+			return NULL;
+		}
+	};
+
+protected:
+	typedef std::vector<ReceiverImplBase<ReturnT, ParamT>*> ReceiversVector;
+	ReceiversVector receivers_;
+};
+
+
+template <typename ReturnT, typename ParamT>
+class ReceiverImpl : public ReceiverImplBase<ReturnT, ParamT>
+{
+public:
+	ReceiverImpl()
+	{}
+
+	virtual ~ReceiverImpl()	{}
+
+	virtual void AddObserver(ObserverImplBase<ReturnT, ParamT>* observer)
+	{
+		observers_.push_back(observer);
+	}
+
+	virtual void RemoveObserver()
+	{
+		ObserversVector::iterator it = observers_.begin();
+		for (; it != observers_.end(); ++it)
+		{
+			(*it)->RemoveReceiver(this);
+		}
+	}
+
+	virtual ReturnT Receive(ParamT param)
+	{
+		return ReturnT();
+	}
+
+	virtual ReturnT Respond(ParamT param, ObserverImplBase<ReturnT, ParamT>* observer)
+	{
+		return ReturnT();
+	}
+
+protected:
+	typedef std::vector<ObserverImplBase<ReturnT, ParamT>*> ObserversVector;
+	ObserversVector observers_;
+};
+
+#endif // OBSERVER_IMPL_BASE_HPP

--- a/ui_components/menu/ui_menu.cpp
+++ b/ui_components/menu/ui_menu.cpp
@@ -15,30 +15,91 @@ Control* CMenuWnd::CreateControl(const std::wstring& pstrClass)
 	return NULL;
 }
 
+BOOL CMenuWnd::Receive(ContextMenuParam param)
+{
+	switch (param.wParam)
+	{
+	case eMenuCloseAll:
+		Close();
+		break;
+	case eMenuCloseThis:
+	{
+		HWND hParent = GetParent(m_hWnd);
+		while (hParent != NULL)
+		{
+			if (hParent == param.hWnd)
+			{
+				Close();
+				break;
+			}
+			hParent = GetParent(hParent);
+		}
+	}
+		break;
+	default:
+		break;
+	}
+
+	return TRUE;
+}
+
 CMenuWnd::CMenuWnd(HWND hParent) :
 	m_hParent(hParent),
 	m_xml(_T("")),
-	no_focus_(false)
+	no_focus_(false),
+	m_pOwner(nullptr),
+	m_pLayout(nullptr)
 {
 }
 
-void CMenuWnd::Init(STRINGorID xml, LPCTSTR pSkinType, POINT point, PopupPosType popupPosType, bool no_focus)
+void CMenuWnd::Init(STRINGorID xml, LPCTSTR pSkinType, POINT point, PopupPosType popupPosType, bool no_focus, CMenuElementUI* pOwner)
 {
 	m_BasedPoint = point;
 	m_popupPosType = popupPosType;
 
-	if (pSkinType != NULL)
-		m_sType = pSkinType;
-
 	m_xml = xml;
 	no_focus_ = no_focus;
+	m_pOwner = pOwner;
+
+	CMenuWnd::GetMenuObserver().AddReceiver(this);
+
 	Create(m_hParent, L"NIM_DUILIB_MENU_WINDOW", WS_POPUP, WS_EX_TOOLWINDOW | WS_EX_TOPMOST, true, UiRect());
 	// HACK: Don't deselect the parent's caption
 	HWND hWndParent = m_hWnd;
 	while (::GetParent(hWndParent) != NULL) hWndParent = ::GetParent(hWndParent);
 	::ShowWindow(m_hWnd, no_focus ? SW_SHOWNOACTIVATE : SW_SHOW);
-	::SetWindowPos(m_hWnd, NULL, m_BasedPoint.x, m_BasedPoint.y, 0, 0, SWP_NOSIZE | (no_focus ? SWP_NOACTIVATE : 0));
+	if (m_pOwner)
+	{
+		ResizeSubMenu();
+	}
+	else
+	{
+		ResizeMenu();
+	}
+	//::SetWindowPos(m_hWnd, NULL, m_BasedPoint.x, m_BasedPoint.y, 0, 0, SWP_NOSIZE | (no_focus ? SWP_NOACTIVATE : 0));
 	::SendMessage(hWndParent, WM_NCACTIVATE, TRUE, 0L);
+}
+
+void CMenuWnd::OnFinalMessage(HWND hWnd)
+{
+	RemoveObserver();
+	if (m_pOwner != NULL) {
+		for (int i = 0; i < m_pLayout->GetCount(); i++) {
+			CMenuElementUI* pItem = static_cast<CMenuElementUI*>(m_pLayout->GetItemAt(i)); //这里确定是CMenuElementUI*，static_cast效率高
+			if (pItem)
+			{
+				pItem->SetOwner(dynamic_cast<IListOwner*>(m_pOwner->GetParent()));//这里的父控件可能仍然是menuitem,那么置空即可
+				pItem->SetWindow(m_pOwner->GetWindow(), m_pOwner, false);         //更改item的归属
+				pItem->SetVisible(false);
+				pItem->SetInternVisible(false);
+			}
+		}
+		m_pLayout->RemoveAll();
+		m_pOwner->m_pSubWindow = NULL;
+		//m_pOwner->m_uButtonState &= ~UISTATE_PUSHED;  这里可能需要替换，暂时注释
+		m_pOwner->Invalidate();
+	}
+	delete this;
 }
 
 std::wstring CMenuWnd::GetWindowClassName() const
@@ -48,20 +109,208 @@ std::wstring CMenuWnd::GetWindowClassName() const
 
 LRESULT CMenuWnd::HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	if (uMsg == WM_KILLFOCUS)
+	switch (uMsg)
 	{
-		Close();
-		return 0;
-	}
-	else if (uMsg == WM_KEYDOWN)
-	{
-		if (wParam == VK_ESCAPE)
-		{
-			Close();
+ 	case WM_KILLFOCUS:
+ 	{
+		HWND hFocusWnd = (HWND)wParam;
+
+		BOOL bInMenuWindowList = FALSE;
+		ContextMenuParam param;
+		param.hWnd = GetHWND();
+
+		ContextMenuObserver::Iterator<BOOL, ContextMenuParam> iterator(GetMenuObserver());
+		ReceiverImplBase<BOOL, ContextMenuParam>* pReceiver = iterator.next();
+		while (pReceiver != NULL) {
+			CMenuWnd* pContextMenu = dynamic_cast<CMenuWnd*>(pReceiver);
+			if (pContextMenu != NULL && pContextMenu->GetHWND() == hFocusWnd) {
+				bInMenuWindowList = TRUE;
+				break;
+			}
+			pReceiver = iterator.next();
 		}
+
+		if (!bInMenuWindowList) {
+			param.wParam = eMenuCloseAll;
+			GetMenuObserver().RBroadcast(param);
+
+			return 0;
+		}
+	}
+		break;
+	case WM_KEYDOWN:
+		if (wParam == VK_ESCAPE || wParam == VK_LEFT)
+			Close();
+		break;
+	case WM_RBUTTONDOWN:
+	case WM_CONTEXTMENU:
+	case WM_RBUTTONUP:
+	case WM_RBUTTONDBLCLK:
+		return 0L;
+
+	default:
+		break;
 	}
 
 	return __super::HandleMessage(uMsg, wParam, lParam);
+}
+
+void CMenuWnd::ResizeMenu()
+{
+	Control* pRoot =GetRoot();
+	MONITORINFO oMonitor = {};
+	oMonitor.cbSize = sizeof(oMonitor);
+	::GetMonitorInfo(::MonitorFromWindow(GetHWND(), MONITOR_DEFAULTTOPRIMARY), &oMonitor);
+	UiRect rcWork = oMonitor.rcWork;
+
+	CSize szAvailable = { rcWork.right - rcWork.left, rcWork.bottom - rcWork.top };
+	szAvailable = pRoot->EstimateSize(szAvailable);
+	SetInitSize(szAvailable.cx, szAvailable.cy);
+
+	CSize szInit = GetInitSize();
+	UiRect rc;
+	CPoint point = m_BasedPoint;
+	rc.left = point.x;
+	rc.top = point.y;
+	rc.right = rc.left + szInit.cx;
+	rc.bottom = rc.top + szInit.cy;
+
+	int nWidth = rc.GetWidth();
+	int nHeight = rc.GetHeight();
+
+// 	if (m_popupPosType & eMenuAlignment_Right)
+// 	{
+// 		rc.right = point.x;
+// 		rc.left = rc.right - nWidth;
+// 	}
+// 
+// 	if (m_popupPosType & eMenuAlignment_Bottom)
+// 	{
+// 		rc.bottom = point.y;
+// 		rc.top = rc.bottom - nHeight;
+// 	}
+
+	SetForegroundWindow(m_hWnd);
+	//MoveWindow(m_hWnd, rc.left, rc.top, rc.GetWidth(), rc.GetHeight(), FALSE);
+	SetWindowPos(m_hWnd, HWND_TOPMOST, rc.left, rc.top,
+		rc.GetWidth(), rc.GetHeight(),
+		SWP_SHOWWINDOW);
+}
+
+void CMenuWnd::ResizeSubMenu()
+{
+	// Position the popup window in absolute space
+	RECT rcOwner = m_pOwner->GetPos();
+	RECT rc = rcOwner;
+
+	int cxFixed = 0;
+	int cyFixed = 0;
+
+	MONITORINFO oMonitor = {};
+	oMonitor.cbSize = sizeof(oMonitor);
+	::GetMonitorInfo(::MonitorFromWindow(GetHWND(), MONITOR_DEFAULTTOPRIMARY), &oMonitor);
+	UiRect rcWork = oMonitor.rcWork;
+	CSize szAvailable = { rcWork.right - rcWork.left, rcWork.bottom - rcWork.top };
+
+	for (int it = 0; it < m_pLayout->GetCount(); it++) {
+		//取子菜单项中的最大值作为菜单项
+		CMenuElementUI* pItem = dynamic_cast<CMenuElementUI*>(m_pLayout->GetItemAt(it));
+		if (pItem)
+		{
+			SIZE sz = pItem->EstimateSize(szAvailable);
+			cyFixed += sz.cy;
+
+			if (cxFixed < sz.cx)
+				cxFixed = sz.cx;
+		}
+	}
+
+	RECT rcWindow;
+	GetWindowRect(m_pOwner->GetWindow()->GetHWND(), &rcWindow);
+
+	rc.top = rcOwner.top;
+	rc.bottom = rc.top + cyFixed;
+	::MapWindowRect(m_pOwner->GetWindow()->GetHWND(), HWND_DESKTOP, &rc);
+	rc.left = rcWindow.right;
+	rc.left -= GetShadowCorner().left + GetShadowCorner().right;
+	rc.top -= GetShadowCorner().top;    //这里有很大的阴影窗口，待准确计算
+	rc.right = rc.left + cxFixed;
+	//rc.right += 2;
+
+	bool bReachBottom = false;
+	bool bReachRight = false;
+	LONG chRightAlgin = 0;
+	LONG chBottomAlgin = 0;
+
+	RECT rcPreWindow = { 0 };
+	ContextMenuObserver::Iterator<BOOL, ContextMenuParam> iterator(GetMenuObserver());
+	ReceiverImplBase<BOOL, ContextMenuParam>* pReceiver = iterator.next();
+	while (pReceiver != NULL) {
+		CMenuWnd* pContextMenu = dynamic_cast<CMenuWnd*>(pReceiver);
+		if (pContextMenu != NULL) {
+			GetWindowRect(pContextMenu->GetHWND(), &rcPreWindow);
+
+			bReachRight = rcPreWindow.left >= rcWindow.right;
+			bReachBottom = rcPreWindow.top >= rcWindow.bottom;
+			if (pContextMenu->GetHWND() == m_pOwner->GetWindow()->GetHWND()
+				|| bReachBottom || bReachRight)
+				break;
+		}
+		pReceiver = iterator.next();
+	}
+
+	if (bReachBottom)
+	{
+		rc.bottom = rcWindow.top;
+		rc.top = rc.bottom - cyFixed;
+	}
+
+	if (bReachRight)
+	{
+		rc.right = rcWindow.left;
+		rc.left = rc.right - cxFixed;
+	}
+
+	if (bReachBottom)
+	{
+		rc.bottom = rcWindow.top;
+		rc.top = rc.bottom - cyFixed;
+	}
+
+	if (bReachRight)
+	{
+		rc.right = rcWindow.left;
+		rc.left = rc.right - cxFixed;
+	}
+
+	if (rc.bottom > rcWork.bottom)
+	{
+		rc.bottom = rc.top;
+		rc.top = rc.bottom - cyFixed;
+	}
+
+	if (rc.right > rcWork.right)
+	{
+		rc.right = rcWindow.left;
+		rc.left = rc.right - cxFixed;
+	}
+
+	if (rc.top < rcWork.top)
+	{
+		rc.top = rcOwner.top;
+		rc.bottom = rc.top + cyFixed;
+	}
+
+	if (rc.left < rcWork.left)
+	{
+		rc.left = rcWindow.right;
+		rc.right = rc.left + cxFixed;
+	}
+
+	//MoveWindow(m_hWnd, rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top , FALSE);
+	SetWindowPos(m_hWnd, HWND_TOPMOST, rc.left, rc.top,
+		rc.right - rc.left, rc.bottom - rc.top,
+		SWP_SHOWWINDOW);
 }
 
 void CMenuWnd::Show()
@@ -118,10 +367,35 @@ void CMenuWnd::Show()
 		SetForegroundWindow(m_hWnd);
 }
 
+
+void CMenuWnd::InitWindow()
+{
+	if (m_pOwner)
+	{
+		m_pLayout = static_cast<ListBox*>(FindControl(L"submenu"));
+		ASSERT(m_pLayout);
+		m_pLayout->SetAutoDestroy(false);
+
+		for (int i = 0; i < m_pOwner->GetCount(); i++) {
+			CMenuElementUI* subMenuItem = dynamic_cast<CMenuElementUI*>(m_pOwner->GetItemAt(i));
+			if (subMenuItem)
+			{
+				//此时子菜单item属于2个子菜单，注意生命周期的维护，子菜单窗口退出不能销毁控件，需要归还原控件，
+				//此时子菜单item的父控件是准的，但父控件可能不是Vlist，SetOwner的入参是Vlist，这时owner置空
+				//见OnFinalMessage
+				m_pLayout->Add(subMenuItem); //内部会调用subMenuItem->SetOwner(m_pLayout); 会调用SetWindows，改变了归属窗口、父控件。
+			}
+		}
+	}
+}
+
+
+
 // MenuElementUI
 const TCHAR* const kMenuElementUIInterfaceName = _T("MenuElement");
 
-CMenuElementUI::CMenuElementUI()
+CMenuElementUI::CMenuElementUI() :
+m_pSubWindow(nullptr)
 {
 	m_bMouseChildEnabled = false;
 }
@@ -134,10 +408,89 @@ bool CMenuElementUI::ButtonUp(EventArgs& msg)
 	std::weak_ptr<nbase::WeakFlag> weakFlag = m_pWindow->GetWeakFlag();
 	bool ret = __super::ButtonUp(msg);
 	if (ret && !weakFlag.expired()) {
-		m_pWindow->Close();
+		//这里处理下如果有子菜单则显示子菜单
+		if (!CheckSubMenuItem())
+		{
+			ContextMenuParam param;
+			param.hWnd = GetWindow()->GetHWND();
+			param.wParam = eMenuCloseAll;
+			CMenuWnd::GetMenuObserver().RBroadcast(param);
+		}
 	}
 
 	return ret;
+}
+
+
+bool CMenuElementUI::MouseEnter(EventArgs& msg)
+{
+	std::weak_ptr<nbase::WeakFlag> weakFlag = m_pWindow->GetWeakFlag();
+	bool ret = __super::MouseEnter(msg);
+	if (ret && !weakFlag.expired()) {
+		//这里处理下如果有子菜单则显示子菜单
+		if (!CheckSubMenuItem())
+		{
+			ContextMenuParam param;
+			param.hWnd = GetWindow()->GetHWND();
+			param.wParam = eMenuCloseThis;
+			CMenuWnd::GetMenuObserver().RBroadcast(param);
+			m_pOwner->SelectItem(GetIndex(), true);
+		}
+	}
+
+	return ret;
+}
+
+void CMenuElementUI::PaintChild(IRenderContext* pRender, const UiRect& rcPaint)
+{
+	UiRect rcTemp;
+	if (!::IntersectRect(&rcTemp, &rcPaint, &m_rcItem)) return;
+
+	for (auto it = m_items.begin(); it != m_items.end(); it++) {
+		//尝试转CMenuElementUI
+		CMenuElementUI* subMenuItem = dynamic_cast<CMenuElementUI*>(*it);
+		if (subMenuItem)
+		{
+			continue;
+		}
+		Control* pControl = *it;
+		if (!pControl->IsVisible()) continue;
+		pControl->AlphaPaint(pRender, rcPaint);
+	}
+}
+
+bool CMenuElementUI::CheckSubMenuItem()
+{
+	bool hasSubMenu = false;
+	for (int i = 0; i < GetCount(); ++i)
+	{
+		CMenuElementUI* subMenuItem = dynamic_cast<CMenuElementUI*>(GetItemAt(i));
+		if (subMenuItem)
+		{
+			subMenuItem->SetVisible(true);
+			subMenuItem->SetInternVisible(true);
+			hasSubMenu = true;
+		}
+	}
+	if (hasSubMenu)
+	{
+		m_pOwner->SelectItem(GetIndex(), true);
+		CreateMenuWnd();
+	}
+	return hasSubMenu;
+}
+
+void CMenuElementUI::CreateMenuWnd()
+{
+	if (m_pSubWindow) return;
+	m_pSubWindow = new CMenuWnd(GetWindow()->GetHWND());
+
+	ContextMenuParam param;
+	param.hWnd =GetWindow()->GetHWND();
+	param.wParam = eMenuCloseThis;
+	CMenuWnd::GetMenuObserver().RBroadcast(param);
+
+	m_pSubWindow->Init(_T("submenu.xml"), _T(""), CPoint(), CMenuWnd::RIGHT_BOTTOM, false, this);
 }
 
 } // namespace ui

--- a/ui_components/menu/ui_menu.h
+++ b/ui_components/menu/ui_menu.h
@@ -6,52 +6,89 @@
 namespace nim_comp {
 
 using namespace ui;
-
 enum MenuAlignment
 {
 	eMenuAlignment_Left = 1 << 1,
 	eMenuAlignment_Top = 1 << 2,
 	eMenuAlignment_Right = 1 << 3,
 	eMenuAlignment_Bottom = 1 << 4,
+	eMenuAlignment_Intelligent = 1 <<5    //待优化，智能的防止被遮蔽
 };
+
+enum MenuCloseType
+{
+	eMenuCloseThis,  //适用于关闭当前级别的菜单窗口，如鼠标移入时
+	eMenuCloseAll     //关闭所有菜单窗口，如失去焦点时
+};
+
+//增加关闭事件的传递。
+/*
+点击某一菜单，获取该菜单窗口句柄，通知该菜单窗口可以关闭子菜单项了。
+即某子菜单项目的父窗口等于该窗口，该子菜单关闭。
+由于菜单的父子关系，会自动关闭其所有子孙菜单窗口
+这里的事件传递设计拷贝原生Duilib的MenuDemo，不过Redrain的Menu功能更好，支持菜单复选，这里暂未实现
+*/
+#include "observer_impl_base.hpp"   //copy from menuDemo
+struct ContextMenuParam
+{
+	MenuCloseType wParam;
+	HWND hWnd;
+};
+
+typedef class ObserverImpl<BOOL, ContextMenuParam> ContextMenuObserver;
+typedef class ReceiverImpl<BOOL, ContextMenuParam> ContextMenuReceiver;
 
 /////////////////////////////////////////////////////////////////////////////////////
 //
 
+
 extern const TCHAR* const kMenuElementUIInterfaceName;// = _T("MenuElement);
 class CMenuElementUI;
-class CMenuWnd : public ui::WindowImplBase
+class CMenuWnd : public ui::WindowImplBase, public ContextMenuReceiver
 {
 public:
-	virtual Control* CreateControl(const std::wstring& pstrClass) override;
-
 	enum PopupPosType
 	{
-		RIGHT_BOTTOM,
-		RIGHT_TOP
+		RIGHT_BOTTOM = eMenuAlignment_Right | eMenuAlignment_Bottom,
+		RIGHT_TOP = eMenuAlignment_Right | eMenuAlignment_Top,
+		//这里待添加另外的类型
 	};
-
 	CMenuWnd(HWND hParent = NULL);
-	void Init(STRINGorID xml, LPCTSTR pSkinType, POINT point, PopupPosType popupPosType = RIGHT_BOTTOM, bool no_focus = false);
-	std::wstring GetWindowClassName() const;
+	void Init(STRINGorID xml, LPCTSTR pSkinType, POINT point, PopupPosType popupPosType = RIGHT_BOTTOM, bool no_focus = false, CMenuElementUI* pOwner = NULL);
+	void Show();
 
-	LRESULT HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam);
+	static ContextMenuObserver& GetMenuObserver()
+	{
+		static ContextMenuObserver s_context_menu_observer;
+		return s_context_menu_observer;
+	}
+	BOOL Receive(ContextMenuParam param) override;
+	
+	virtual Control* CreateControl(const std::wstring& pstrClass) override;
 	virtual std::wstring GetSkinFolder() override {
 		return L"menu";
 	}
 	virtual std::wstring GetSkinFile() override {
 		return m_xml.m_lpstr;
 	}
-
-	void Show();
+	std::wstring GetWindowClassName() const override;
 
 public:
 	HWND m_hParent;
 	POINT m_BasedPoint;
 	PopupPosType m_popupPosType;
 	STRINGorID m_xml;
-	std::wstring m_sType;
 	bool no_focus_;
+	CMenuElementUI* m_pOwner;
+	ListBox* m_pLayout;
+private:
+	virtual void InitWindow() override;
+	void CMenuWnd::OnFinalMessage(HWND hWnd) override;
+	LRESULT HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam);
+	// 重新调整菜单的大小
+	void ResizeMenu();
+	// 重新调整子菜单的大小
+	void ResizeSubMenu();
 };
 
 class ListContainerElement;
@@ -63,6 +100,14 @@ public:
 	~CMenuElementUI();
 
 	virtual bool ButtonUp(EventArgs& msg) override;
+	virtual bool MouseEnter(EventArgs& msg) override;
+
+	virtual void PaintChild(IRenderContext* pRender, const UiRect& rcPaint) override;
+
+private:
+	bool CheckSubMenuItem();
+	void CreateMenuWnd();
+	CMenuWnd*	m_pSubWindow;
 };
 
 } // namespace nim_comp


### PR DESCRIPTION
<!-- 这里写下您的 PR 修复了什么问题或新增了什么功能 -->
Fixed #
多级菜单的实现，支持xml中静态添加或者代码中动态添加
<!-- 请确保您的拉取求情提交至开发分（development）支而不是主分支（master） -->
<!-- 请仔细查看您的提交确保同文件下使用的是与原项目相同的缩进方式和代码风格 -->
<!-- 写下您的 PR 工作的具体内容，比如解决问题的思路和新功能的作用 -->
原理：
1、所有的菜单项资源保存到主菜单中。菜单项里面的子菜单项不执行Paint操作并隐藏（这里可能直接隐藏也行，还没试。隐藏不行，当子菜单窗口设为可见时，会造成干扰。）
2、当菜单事件触发时，检查是否有子菜单项，有，则生成一个带Listbox（不自动销毁）的子窗口，Listbox填充该子菜单项，注意 setwindow的切换，onwer等的切换。
3、带一个事件传递串，所有的菜单窗口均能收到close通知，因为业务决定关闭所有菜单或者某子菜单。
4、当菜单销毁时，注意 setwindow的切换，onwer等的切换。