### PR TITLE
修复把控件设置为禁用状态时，在丢失焦点和获取焦点时会自动设置成非禁用状态

### DIFF
--- a/duilib/Core/Control.cpp
+++ b/duilib/Core/Control.cpp
@@ -802,18 +802,18 @@ void Control::HandleMessage(EventArgs& msg)
 			ASSERT(FALSE);
 		}
 	}
-	else if (msg.Type == kEventInternalSetFocus) {
+	else if (msg.Type == kEventInternalSetFocus && m_uButtonState != kControlStateDisabled) {
 		SetState(kControlStateHot);
-        m_bFocused = true;
-        Invalidate();
+		m_bFocused = true;
+		Invalidate();
 		return;
-    }
-	else if (msg.Type == kEventInternalKillFocus) {
+	}
+	else if (msg.Type == kEventInternalKillFocus && m_uButtonState != kControlStateDisabled) {
 		SetState(kControlStateNormal);
-        m_bFocused = false;
-        Invalidate();
+		m_bFocused = false;
+		Invalidate();
 		return;
-    }
+	}
 	else if (msg.Type == kEventInternalMenu && IsEnabled()) {
         if( IsContextMenuUsed() ) {
             m_pWindow->SendNotify(this, kEventMouseMenu, msg.wParam, msg.lParam);


### PR DESCRIPTION
Fixed # 修复把控件设置为禁用状态时，在丢失焦点和获取焦点时会自动设置成非禁用状态
