### PR TITLE
修复ChildBox无法使用自定义控件的问题

### DIFF
--- a/duilib/Box/ChildBox.cpp
+++ b/duilib/Box/ChildBox.cpp
@@ -13,7 +13,12 @@ void ChildBox::Init()
 {
 	if (!m_strXMLFile.empty())
 	{
-		Box* pChildWindow = static_cast<Box*>(GlobalManager::CreateBoxWithCache(m_strXMLFile.c_str(), CreateControlCallback()));
+		CreateControlCallback callback = CreateControlCallback();
+		auto pBaseWindow = dynamic_cast<WindowImplBase*>(m_pWindow);
+		if (pBaseWindow != nullptr)
+			callback = std::bind(&WindowImplBase::CreateControl, pBaseWindow, std::placeholders::_1);
+
+		Box* pChildWindow = static_cast<Box*>(GlobalManager::CreateBoxWithCache(m_strXMLFile.c_str(), callback));
 		if (pChildWindow) {
 			this->Add(pChildWindow);
 		}


### PR DESCRIPTION
Fixed # ChildBox无法使用自定义控件的问题, 比如：

```c++
ui::Control* DateTimeForm::CreateControl(const std::wstring& pstrClass)
{
    if (pstrClass == L"DateTime")
    {
        return new ui::DateTime();
    }

    return nullptr;
}
```

