### PR TITLE
fix StringAppendVT bug

### DIFF
--- a/base/util/string_util.cpp
+++ b/base/util/string_util.cpp
@@ -141,7 +141,11 @@ size_t StringReplaceAllT(const std::basic_string<CharType> &find,
 
 inline int vsnprintfT(char *dst, size_t count, const char *format, va_list ap)
 {
+#if defined(OS_WIN)	
+	return _vsnprintf(dst, count, format, ap);
+#else	
 	return vsnprintf(dst, count, format, ap);
+#endif	
 }
 
 inline int vsnprintfT(wchar_t *dst, size_t count, const wchar_t *format, va_list ap)
@@ -176,11 +180,13 @@ void StringAppendVT(const CharType *format, va_list ap, std::basic_string<CharTy
 	std::basic_string<CharType> heap_buffer;
 	for (;;)
 	{
-		if (result != -1)
+#if !defined(OS_WIN)
+		if (result < 0)
 		{
 			assert(0);
 			return; /* not expected, result should be -1 here */
 		}
+#endif
 		buffer_size <<= 1; /* try doubling the buffer size */
 		if (buffer_size > 32 * 1024 * 1024)
 		{


### PR DESCRIPTION
<!-- 这里写下您的 PR 修复了什么问题或新增了什么功能 -->
Fixed #385 

<!-- 请确保您的拉取求情提交至开发分（development）支而不是主分支（master） -->
<!-- 请仔细查看您的提交确保同文件下使用的是与原项目相同的缩进方式和代码风格 -->
<!-- 写下您的 PR 工作的具体内容，比如解决问题的思路和新功能的作用 -->

看了代码实现和文档说明，并且做了测试。

https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/vsnprintf-vsnprintf-vsnprintf-l-vsnwprintf-vsnwprintf-l?view=msvc-140

微软的文档中，vsnprintf 和 _vsnwprintf 的返回在某些情况并不一致。前者在超过缓存大小的情况，返回是要写入到缓存的字符长度，出错则返回-1，后者则是缓存不足的情况会返回-1。然而 _vsnprintf 则与 _vsnwprintf 保持一致的。在 Windows 10 和 MSVS 2017 的本地测试也确实表现如此。

在微软的文档中，没有找到符合 the C99 standard 的可以用来替换 _vsnwprintf 的函数。

另外，在gcc的在线调试中，vsnprintf 和 vswprintf 的返回保持统一，都是超过缓存大小的情况，返回要写入到缓存的字符长度，出错则返回-1。

这样的话，在 Windows 上，统一使用 _vsnprintf 以及 _vsnwprintf，但result为负数的断言通过宏取消了。非 Windows 平台，则可以检测返回负数出错的情况。
